### PR TITLE
fix issue #1 on master

### DIFF
--- a/src/android/Focus.java
+++ b/src/android/Focus.java
@@ -43,12 +43,12 @@ public class Focus extends CordovaPlugin {
             // Compute its center
             final Integer centerLeft = (int) (left + ((right - left) / 2));
             final Integer centerTop = (int) (top + ((bottom - top) / 2));
-
             // Emulate click
             cordova.getActivity().runOnUiThread(new Runnable() {
               public void run() {
-                webView.dispatchTouchEvent(MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(), MotionEvent.ACTION_DOWN, centerLeft, centerTop, 0));
-                webView.dispatchTouchEvent(MotionEvent.obtain(SystemClock.uptimeMillis(), SystemClock.uptimeMillis(), MotionEvent.ACTION_UP, centerLeft, centerTop, 0));
+                final long uMillis=SystemClock.uptimeMillis();
+                webView.dispatchTouchEvent(MotionEvent.obtain(uMillis, uMillis, MotionEvent.ACTION_DOWN, centerLeft, centerTop, 0));
+                webView.dispatchTouchEvent(MotionEvent.obtain(uMillis, uMillis, MotionEvent.ACTION_UP, centerLeft, centerTop, 0));
               }
             });
             return true;


### PR DESCRIPTION
https://github.com/46cl/cordova-android-focus-plugin/issues/1
timing issues caused the click to be interpreted as a long click,
showing a menu with "Paste".
