### PR TITLE
fix master issue #6

### DIFF
--- a/src/android/Focus.java
+++ b/src/android/Focus.java
@@ -10,6 +10,7 @@ import org.json.JSONObject;
 import org.json.JSONException;
 
 import android.os.SystemClock;
+import android.os.Build;
 import android.view.MotionEvent;
 import android.util.DisplayMetrics;
 import android.content.Context;
@@ -33,6 +34,8 @@ public class Focus extends CordovaPlugin {
             DisplayMetrics metrics = this.cordova.getActivity().getApplicationContext().getResources().getDisplayMetrics();
             float density = metrics.density;
 
+			if (android.os.Build.VERSION.SDK_INT<19)
+				density=1;
             // Get bounding positions of target element
             JSONObject rect = args.getJSONObject(0);
             float left = (density *  rect.getInt("left"));

--- a/www/focus.js
+++ b/www/focus.js
@@ -7,16 +7,17 @@ var Focus = function() {
 
 Focus.focus = function(element) {
     element = element.length ? element[0] : element;
-    var elemRect = element.getBoundingClientRect();
-    var bodyRect = document.body.getBoundingClientRect();
-
+    var jelement = $(element);
+    var offset = jelement.offset();
+    offset.top = offset.top - $(window).scrollTop();
+    offset.left = offset.left - $(window).scrollLeft();
         rect = {
-            top: elemRect.top - bodyRect.top - window.pageYOffset,
-            left: elemRect.left - bodyRect.left - window.pageXOffset,
-            right: elemRect.right - bodyRect.left - window.pageXOffset,
-          bottom: elemRect.bottom - bodyRect.top - window.pageYOffset
+            top: offset.top,
+            left: offset.left,
+            right: offset.left + jelement.width(),
+            bottom: offset.top + jelement.height()
         };
-    exec(null, null, "Focus", "focus", [rect]);
+        exec(null, null, "Focus", "focus", [rect]);
 };
 
 module.exports = Focus;


### PR DESCRIPTION
issue: https://github.com/46cl/cordova-android-focus-plugin/issues/6
in android before 4.4 the webview coordinates did not use density.
https://developer.android.com/guide/webapps/migrating.html

java code has this fix.
javascript code is optional. it uses the "jquery way" of calculating the rectangle. I initially changed it hoping that it would fix the issue. it didnt but I think why not reuse .offset, seems cleaner.
